### PR TITLE
Changed .NET code to PowerShell cmdlet

### DIFF
--- a/web/requestbin/templates/bin.html
+++ b/web/requestbin/templates/bin.html
@@ -58,7 +58,7 @@
       <pre>curl -X POST -d "fizz=buzz" {{base_url}}/{{bin.name}}</pre>
 
       <h5>PowerShell</h5>
-      <pre>powershell -NoLogo -Command "(New-Object System.Net.WebClient).DownloadFile('{{base_url}}/{{bin.name}}', 'C:\Windows\Temp\{{bin.name}}.txt')"</pre>
+      <pre>(Invoke-WebRequest -Uri '{{base_url}}/{{bin.name}}').Content</pre>
 
       <h5>Python (with Requests)</h5>
       <pre class="prettyprint">import requests, time


### PR DESCRIPTION
- Bad practice to use .NET code in PowerShell when a cmdlet does the same job.
- PowerShell code started a new PowerShell process - PowerShell was the only code example meant to be used in a run command?
- No reason to save http response in 'C:\Windows\Temp\{{bin.name}}.txt'.
- This change also makes PowerShell send a user-agent string to RequestBin, e.g. "User-Agent: Mozilla/5.0 (Windows NT; Windows NT 10.0; en-US) WindowsPowerShell/5.1.18362.145"

For using the code with a run command:
`powershell -NoLogo -Command "(Invoke-WebRequest -Uri '{{base_url}}/{{bin.name}}').Content"`