### PR TITLE
Add "-L" option to cURL cmdline example

### DIFF
--- a/web/requestbin/templates/bin.html
+++ b/web/requestbin/templates/bin.html
@@ -55,7 +55,7 @@
       <h4>Make a request to get started.</h4>
 
       <h5>cURL</h5>
-      <pre>curl -X POST -d "fizz=buzz" {{base_url}}/{{bin.name}}</pre>
+      <pre>curl -X POST -d "fizz=buzz" -L {{base_url}}/{{bin.name}}</pre>
 
       <h5>PowerShell</h5>
       <pre>powershell -NoLogo -Command "(New-Object System.Net.WebClient).DownloadFile('{{base_url}}/{{bin.name}}', 'C:\Windows\Temp\{{bin.name}}.txt')"</pre>


### PR DESCRIPTION
It looks like an http POST to https://requestbin.net/ returns status 301 (Moved Permanently)

```
udooer@udooneogm01:~$ curl -X POST -d "fizz=buzz" -v http://requestbin.net/r/4l9847t6
* Hostname was NOT found in DNS cache
*   Trying 172.67.190.62...
* Connected to requestbin.net (172.67.190.62) port 80 (#0)
> POST /r/4l9847t6 HTTP/1.1
> User-Agent: curl/7.35.0
> Host: requestbin.net
> Accept: */*
> Content-Length: 9
> Content-Type: application/x-www-form-urlencoded
>
* upload completely sent off: 9 out of 9 bytes
< HTTP/1.1 301 Moved Permanently
< Date: Sun, 25 Apr 2021 04:59:43 GMT
< Transfer-Encoding: chunked
< Connection: keep-alive
< Cache-Control: max-age=3600
< Expires: Sun, 25 Apr 2021 05:59:43 GMT
< Location: https://requestbin.net/r/4l9847t6
< cf-request-id: 09a8fee86d00004c68cbaf0000000001
< Report-To: {"max_age":604800,"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report?s=qpZdu%2FY9VKAjNH09PSSYaFROLX4V2sidbWt0M3VqASQZWAfiOBeXzMUNyAGrjmLNYqlhxUZY4uisDDMwEZYyse13WvYTK5tvubOQ3o4V1Q%3D%3D"}],"group":"cf-nel"}
< NEL: {"report_to":"cf-nel","max_age":604800}
* Server cloudflare is not blacklisted
< Server: cloudflare
< CF-RAY: 645500ed79cf4c68-AMS
< alt-svc: h3-27=":443"; ma=86400, h3-28=":443"; ma=86400, h3-29=":443"; ma=86400
<
* Connection #0 to host requestbin.net left intact
udooer@udooneogm01:~$
```

The "-L" option to curl allows the http POST to complete successfully with status 200 OK

```
udooer@udooneogm01:~$ curl -X POST -d "fizz=buzz" -L http://requestbin.net/r/4l9847t6
ip:130.192.16.67
udooer@udooneogm01:~$
```

Please refer to "man curl" for details.

Signed-off-by: Gianpaolo Macario <gmacario@gmail.com>